### PR TITLE
fix: test action permission

### DIFF
--- a/.github/workflows/workflow-tests.yml
+++ b/.github/workflows/workflow-tests.yml
@@ -14,7 +14,7 @@ jobs:
   tests:
     runs-on: ubuntu-20.04
     permissions:
-      contents: read
+      contents: write
       pull-requests: write
       statuses: write
     steps:


### PR DESCRIPTION
# Description

- Allow test reusable workflow to commit to the Wiki

## Reason

We need to store the base coverage file in the wiki, so that we can check if PRs are increasing or decreasing the coverage over time.

---

<!-- Auto-generated section. DO NOT DELETE -->
