### PR TITLE
fix: remove the deployed storybook when the PR is closed

### DIFF
--- a/.github/workflows/on-pull-request-close.yml
+++ b/.github/workflows/on-pull-request-close.yml
@@ -1,0 +1,18 @@
+name: Feature Branch
+
+on:
+  pull_request:
+    types:
+      - closed
+
+concurrency: preview-${{ github.ref }}
+
+jobs:
+  clean-deployment:
+    if: github.event.action == 'closed' && github.event.pull_request.draft == false
+    runs-on: ubuntu-20.04
+    steps:
+      - name: Deploy preview
+        uses: rossjrw/pr-preview-action@v1
+        with:
+          custom-url: percoct-ui.yld.engineering

--- a/.github/workflows/on-pull-request.yml
+++ b/.github/workflows/on-pull-request.yml
@@ -58,20 +58,3 @@ jobs:
       repo_token: ${{secrets.GITHUB_TOKEN}}
     with:
       storybook_url: ${{ needs.deployment.outputs.environment_url }}
-
-  # Remove the deployed Storybook when we close the PR
-  clean-deployment:
-    if: github.event.action == 'closed' && github.event.pull_request.draft == false
-    runs-on: ubuntu-20.04
-    environment:
-      name: github-pages
-      url: ${{ steps.preview.outputs.deployment-url }}
-    outputs:
-      environment_url: ${{ steps.preview.outputs.deployment-url }}
-    steps:
-      - name: Deploy preview
-        uses: rossjrw/pr-preview-action@v1
-        id: "preview"
-        with:
-          custom-url: percoct-ui.yld.engineering
-          source-dir: ./storybook-static/


### PR DESCRIPTION
# Description

- Add on-pull-request-close workflow

## Reason

The deployment only runs when the build ran previously.
However we need to run the deployment step when the PR is closed in order to clean up the deployed storybook, without having to run the build step again.

---

<!-- Auto-generated section. DO NOT DELETE -->
