### PR TITLE
fix: workflow permissions for semantic-release

### DIFF
--- a/.github/workflows/on-pull-request.yml
+++ b/.github/workflows/on-pull-request.yml
@@ -24,7 +24,7 @@ jobs:
     uses: ./.github/workflows/workflow-build-library.yml
     permissions:
       attestations: write
-      contents: read
+      contents: write
     secrets:
       repo_token: ${{secrets.GITHUB_TOKEN}}
       npm_token: ${{secrets.NPM_TOKEN}}
@@ -35,7 +35,7 @@ jobs:
     if: github.event.pull_request.draft == false
     uses: ./.github/workflows/workflow-build-storybook.yml
     permissions:
-      contents: write
+      contents: read
     secrets:
       repo_token: ${{secrets.GITHUB_TOKEN}}
 

--- a/.github/workflows/on-pull-request.yml
+++ b/.github/workflows/on-pull-request.yml
@@ -35,7 +35,7 @@ jobs:
     if: github.event.pull_request.draft == false
     uses: ./.github/workflows/workflow-build-storybook.yml
     permissions:
-      contents: read
+      contents: write
     secrets:
       repo_token: ${{secrets.GITHUB_TOKEN}}
 

--- a/.github/workflows/workflow-build-library.yml
+++ b/.github/workflows/workflow-build-library.yml
@@ -17,7 +17,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       attestations: write
-      contents: read
+      contents: write # semantic-release requires permission even in dry-run mode
     outputs:
       manifest_name: ${{steps.tarball.outputs.manifest_name}}
       tarball_name: ${{steps.tarball.outputs.tarball_name}}
@@ -97,7 +97,7 @@ jobs:
       contents: read
     strategy:
       matrix:
-        node-version: [18, 20]
+        node-version: [20, 22]
     name: Test Node ${{ matrix.node-version }}
     steps:
       - uses: actions/setup-node@1d0ff469b7ec7b3cb9d8673fde0c81c44821de2a #v4.2.0
@@ -118,7 +118,7 @@ jobs:
             "private": true,
             "type": "module",
             "engines": {
-              "node": ">=18"
+              "node": ">=20"
             }
           }
           EOF


### PR DESCRIPTION
semantic-release requires write permissions even in dry-run mode